### PR TITLE
Implement CD workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,9 @@ jobs:
       - name: Archive artifact (Windows)
         if: ${{ matrix.os == 'windows-latest' }}
         working-directory: output
-        run: 7z a -tzip ${{ matrix.artifact }}.zip *
+        run: |
+          7z a -tzip ${{ matrix.artifact }}.zip *
+          rm ${{ matrix.artifact }}
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,9 +73,11 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          path: './artifacts'
+          path: artifacts
+      - name: List artifacts
+        run: ls -R artifacts
       - name: Create release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
-          files: artifacts/**/*
+          files: artifacts/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,12 +29,12 @@ jobs:
           #   target: x86_64-apple-darwin
           #   use-zigbuild: true
           #   strip: true
-          #   artifact: protoflow-darwin-x64
+          #   artifact: protoflow-macos-x64
           # - os: macos-latest
           #   target: aarch64-apple-darwin
           #   use-zigbuild: true
           #   strip: false
-          #   artifact: protoflow-darwin-arm64
+          #   artifact: protoflow-macos-arm64
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             use-zigbuild: false # zigbuild doesn't support Windows
@@ -48,8 +48,8 @@ jobs:
         with:
           target: ${{ matrix.target }}
           artifact-name: ${{ matrix.artifact }}
-          strip: ${{ matrix.strip }}
-          use-zigbuild: ${{ matrix.use-zigbuild }}
+          strip: ${{ matrix.strip || 'false' }}
+          use-zigbuild: ${{ matrix.use-zigbuild || 'false' }}
 
   release:
     name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: github.event.ref_type == 'tag'
+    if: startsWith(github.ref, 'refs/tags/')
     needs: build
     steps:
       - name: Download artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,20 +61,21 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }}
       - name: Rename artifact
         run: |
-          mkdir .output
-          mv target/${{ matrix.target }}/release/protoflow${{ matrix.os == 'windows-latest' && '.exe' || '' }} .output/${{ matrix.artifact }}
+          mkdir output
+          mv target/${{ matrix.target }}/release/protoflow${{ matrix.os == 'windows-latest' && '.exe' || '' }} output/${{ matrix.artifact }}
       - name: Compress artifact
         if: ${{ matrix.os != 'windows-latest' }}
-        working-directory: .output
+        working-directory: output
         run: gzip -f ${{ matrix.artifact }}
       - name: Archive artifact
         if: ${{ matrix.os == 'windows-latest' }}
-        run: 7z a -tzip .output/${{ matrix.artifact }}.zip .output/*
+        run: 7z a -tzip output/${{ matrix.artifact }}.zip output/*
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.target }}
-          path: .output/*
+          path: output/*
+          if-no-files-found: error
   release:
     name: Release
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,65 +15,26 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          # Linux native
           - os: ubuntu-latest
             artifact: linux-x64
             target: x86_64-unknown-linux-gnu
-            use-zigbuild: false # no reason to use zigbuild when building for host
             strip: true
           - os: ubuntu-latest
             artifact: linux-arm64
             target: aarch64-unknown-linux-gnu
             use-zigbuild: true
-            strip: false
-          # Linux to macOS
           - os: ubuntu-latest
             artifact: macos-x64
             target: x86_64-apple-darwin
             use-zigbuild: true
-            strip: false
           - os: ubuntu-latest
             artifact: macos-arm64
             target: aarch64-apple-darwin
             use-zigbuild: true
-            strip: false
-          # macOS native
-          - os: macos-latest
-            artifact: macos-native-x64
-            target: x86_64-apple-darwin
-            use-zigbuild: false
-            strip: true
-          - os: macos-latest
-            artifact: macos-native-arm64
-            target: aarch64-apple-darwin
-            use-zigbuild: false
-            strip: false
-          # Linux to Windows
           - os: ubuntu-latest
             artifact: windows-x64-gnu
             target: x86_64-pc-windows-gnu
             extension: exe
-            use-zigbuild: false
-            strip: false
-          # Windows native
-          - os: windows-latest
-            artifact: windows-native-x64-gnu
-            target: x86_64-pc-windows-gnu
-            extension: exe
-            use-zigbuild: false
-            strip: false
-          - os: windows-latest
-            artifact: windows-native-x64-msvc
-            target: x86_64-pc-windows-msvc
-            extension: exe
-            use-zigbuild: false
-            strip: false
-          - os: windows-latest
-            artifact: windows-native-arm64
-            target: aarch64-pc-windows-msvc
-            extension: exe
-            use-zigbuild: false
-            strip: false
     name: Build ${{ matrix.artifact }}
     runs-on: ${{ matrix.os }}
     continue-on-error: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,5 @@
 name: Release
 
-# TODO:
-# - Support signing macos binaries.
-
 # Trigger on any tag creation.
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,22 +23,22 @@ jobs:
             target: x86_64-unknown-linux-gnu
             use-zigbuild: false # no reason to use zigbuild when building for host
             artifact: protoflow
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-            use-zigbuild: true
-            artifact: protoflow
+          # - os: ubuntu-latest
+          #   target: aarch64-unknown-linux-gnu
+          #   use-zigbuild: true
+          #   artifact: protoflow
           - os: macos-latest
             target: aarch64-apple-darwin
             use-zigbuild: true
             artifact: protoflow
-          - os: macos-latest
-            target: x86_64-apple-darwin
-            use-zigbuild: true
-            artifact: protoflow
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            use-zigbuild: false # zigbuild doesn't support Windows
-            artifact: protoflow.exe
+          # - os: macos-latest
+          #   target: x86_64-apple-darwin
+          #   use-zigbuild: true
+          #   artifact: protoflow
+          # - os: windows-latest
+          #   target: x86_64-pc-windows-msvc
+          #   use-zigbuild: false # zigbuild doesn't support Windows
+          #   artifact: protoflow.exe
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
             artifact: macos-x64
             target: x86_64-apple-darwin
             use-zigbuild: true
-            strip: true
+            strip: false
           - os: ubuntu-latest
             artifact: macos-arm64
             target: aarch64-apple-darwin
@@ -74,7 +74,7 @@ jobs:
             extension: exe
             use-zigbuild: false
             strip: false
-    name: Build ${{ matrix.target }}
+    name: Build ${{ matrix.artifact }}
     runs-on: ${{ matrix.os }}
     continue-on-error: true
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         include:
           # Linux native
@@ -76,7 +76,7 @@ jobs:
             strip: false
     name: Build ${{ matrix.artifact }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: true
+    continue-on-error: false
     steps:
       - name: Build
         uses: AsimovPlatform/build-rust-action@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: Release
+
+# Trigger on any tag creation.
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            use-zigbuild: false
+            artifact: protoflow
+          # - os: macos-latest
+          #   target: x86_64-apple-darwin
+          #   use-zigbuild: true
+          #   artifact: protoflow
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            use-zigbuild: false
+            artifact: protoflow.exe
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install Rust and target
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          target: ${{ matrix.target }}
+      - name: Install zig
+        if: ${{ matrix.use-zigbuild }}
+        uses: mlugg/setup-zig@v1
+      - name: Install cargo-zigbuild
+        if: ${{ matrix.use-zigbuild }}
+        run: cargo install --locked cargo-zigbuild
+      - name: Build using cargo-zigbuild
+        if: ${{ matrix.use-zigbuild }}
+        run: cargo zigbuild --release --target ${{ matrix.target }}
+      - name: Build
+        if: ${{ !matrix.use-zigbuild }}
+        run: cargo build --release --target ${{ matrix.target }}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: release-${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/${{ matrix.artifact }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,13 +105,13 @@ jobs:
           path: repo
       - name: Parse changelog
         id: query-release-info
-        uses: release-flow/keep-a-changelog-action@v2
+        uses: release-flow/keep-a-changelog-action@v3
         with:
           command: query
           version: latest
           changelog: repo/CHANGES.md
       - name: Create release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@v2
         with:
           body: ${{ steps.query-release-info.outputs.release-notes }}
           tag_name: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Compress artifact
         if: ${{ matrix.os != 'windows-latest' }}
         working-directory: .output
-        run: gzip -f *
+        run: gzip -f ${{ matrix.artifact }}
       - name: Archive artifact
         if: ${{ matrix.os == 'windows-latest' }}
         run: 7z a -tzip .output/${{ matrix.artifact }}.zip .output/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
     continue-on-error: false
     steps:
       - name: Build
-        uses: AsimovPlatform/build-rust-action@master
+        uses: AsimovPlatform/build-rust-action@v1
         with:
           target: ${{ matrix.target }}
           package-extension: ${{ matrix.extension }}
@@ -53,6 +53,6 @@ jobs:
     needs: build
     steps:
       - name: Download artifacts
-        uses: AsimovPlatform/release-action@master
+        uses: AsimovPlatform/release-action@v1
         with:
           changelog_path: CHANGES.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           # Linux native
@@ -76,6 +76,7 @@ jobs:
             strip: false
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: true
     steps:
       - name: Build
         uses: AsimovPlatform/build-rust-action@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release
 
 # TODO:
-# - Strip binaries.
 # - Support signing macos binaries.
 # - Pull changes from changes.md
 
@@ -62,6 +61,10 @@ jobs:
         run: |
           mkdir output
           mv target/${{ matrix.target }}/release/protoflow${{ matrix.os == 'windows-latest' && '.exe' || '' }} output/${{ matrix.artifact }}
+      - name: Strip artifact (*nix)
+        if: ${{ matrix.os != 'windows-latest' }}
+        working-directory: output
+        run: strip ${{ matrix.artifact }}
       - name: Compress artifact (*nix)
         if: ${{ matrix.os != 'windows-latest' }}
         working-directory: output

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,10 +63,17 @@ jobs:
         run: |
           mkdir .output
           mv target/${{ matrix.target }}/release/protoflow${{ matrix.os == 'windows-latest' && '.exe' || '' }} .output/${{ matrix.artifact }}
-      - uses: actions/upload-artifact@v4
+      - name: Compress artifact
+        if: ${{ matrix.os != 'windows-latest' }}
+        run: gzip .output/*
+      - name: Archive artifact
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: 7z a -tzip .output/${{ matrix.artifact }}.zip .output/*
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.target }}
-          path: .output/${{ matrix.artifact }}
+          path: .output/*
   release:
     name: Release
     runs-on: ubuntu-latest
@@ -78,8 +85,6 @@ jobs:
         with:
           path: artifacts
           merge-multiple: true
-      - name: '[DEBUG] List artifacts'
-        run: ls -R artifacts
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
           mv target/${{ matrix.target }}/release/protoflow${{ matrix.os == 'windows-latest' && '.exe' || '' }} .output/${{ matrix.artifact }}
       - name: Compress artifact
         if: ${{ matrix.os != 'windows-latest' }}
-        run: gzip .output/*
+        run: gzip -f .output/*
       - name: Archive artifact
         if: ${{ matrix.os == 'windows-latest' }}
         run: 7z a -tzip .output/${{ matrix.artifact }}.zip .output/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,16 +70,6 @@ jobs:
         if: ${{ matrix.os == 'windows-latest' }}
         working-directory: output
         run: 7z a -tzip ${{ matrix.artifact }}.zip *
-      - name: Compute hash (*nix)
-        working-directory: output
-        run: 
-          shasum --algorithm 256 "${{ matrix.artifact }}" > "${{ matrix.artifact }}.sha256"
-      - name: Compute hash (Windows)
-        working-directory: output
-        run: |
-          choco install --ignore-checksums dos2unix psutils
-          shasum --algorithm 256 "${{ matrix.artifact }}" > "${{ matrix.artifact }}.sha256"
-          dos2unix "${{ matrix.artifact }}.sha256"
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -97,6 +87,11 @@ jobs:
         with:
           path: artifacts
           merge-multiple: true
+      - name: Compute checksums for artifacts
+        run: |
+          for file in artifacts/*; do
+            shasum --algorithm 256 "$file" > "$file.sha256"
+          done
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           #   artifact: protoflow-macos-arm64
           # - os: windows-latest
           - os: ubuntu-latest
-            target: x86_64-pc-windows-msvc
+            target: x86_64-pc-windows-gnu
             use-zigbuild: false # zigbuild doesn't support Windows
             strip: false
             artifact: protoflow-windows-x64.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,13 +38,13 @@ jobs:
           # - os: windows-latest
           - os: ubuntu-latest
             target: x86_64-pc-windows-gnu
-            package-extension: exe
+            extension: exe
             use-zigbuild: false # zigbuild doesn't support Windows
             strip: false
             artifact: windows-x64.exe
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            package-extension: exe
+            extension: exe
             use-zigbuild: false
             strip: false
             artifact: windows2-x64.exe
@@ -55,6 +55,7 @@ jobs:
         uses: AsimovPlatform/build-rust-action@master
         with:
           target: ${{ matrix.target }}
+          package-extension: ${{ matrix.extension }}
           artifact-name: ${{ matrix.artifact }}
           strip: ${{ matrix.strip || 'false' }}
           use-zigbuild: ${{ matrix.use-zigbuild || 'false' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,8 @@ jobs:
           mv target/${{ matrix.target }}/release/protoflow${{ matrix.os == 'windows-latest' && '.exe' || '' }} .output/${{ matrix.artifact }}
       - name: Compress artifact
         if: ${{ matrix.os != 'windows-latest' }}
-        run: gzip -f .output/*
+        working-directory: output
+        run: gzip -f *
       - name: Archive artifact
         if: ${{ matrix.os == 'windows-latest' }}
         run: 7z a -tzip .output/${{ matrix.artifact }}.zip .output/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,14 +4,13 @@ name: Release
 # - Strip binaries.
 # - Support signing macos binaries.
 # - Specify hashes in release.
-# - Produce targball on unix and zip on windows.
+# - Produce .gz on unix and .zip on windows.
 
 # Trigger on any tag creation.
 on:
   push:
     tags:
       - '*'
-  workflow_dispatch:
 
 jobs:
   build:
@@ -22,23 +21,23 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             use-zigbuild: false # no reason to use zigbuild when building for host
-            artifact: protoflow
+            artifact: protoflow-linux-x64
           # - os: ubuntu-latest
           #   target: aarch64-unknown-linux-gnu
           #   use-zigbuild: true
-          #   artifact: protoflow
+          #   artifact: protoflow-linux-arm64
           - os: macos-latest
             target: aarch64-apple-darwin
             use-zigbuild: true
-            artifact: protoflow
+            artifact: protoflow-darwin-arm64
           # - os: macos-latest
           #   target: x86_64-apple-darwin
           #   use-zigbuild: true
-          #   artifact: protoflow
+          #   artifact: protoflow-darwin-x64
           # - os: windows-latest
           #   target: x86_64-pc-windows-msvc
           #   use-zigbuild: false # zigbuild doesn't support Windows
-          #   artifact: protoflow.exe
+          #   artifact: protoflow-windows-x64.exe
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -60,10 +59,14 @@ jobs:
       - name: Build
         if: ${{ !matrix.use-zigbuild }}
         run: cargo build --release --target ${{ matrix.target }}
+      - name: Rename artifact
+        run: |
+          mkdir .output
+          mv target/${{ matrix.target }}/release/protoflow${{ matrix.os == 'windows-latest' && '.exe' || '' }} .output/${{ matrix.artifact }}
       - uses: actions/upload-artifact@v4
         with:
-          name: protoflow-${{ matrix.target }}
-          path: target/${{ matrix.target }}/release/${{ matrix.artifact }}
+          name: ${{ matrix.target }}
+          path: .output/${{ matrix.artifact }}
   release:
     name: Release
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,8 @@ jobs:
           #   use-zigbuild: true
           #   strip: false
           #   artifact: protoflow-macos-arm64
-          - os: windows-latest
+          # - os: windows-latest
+          - os: ubuntu-latest
             target: x86_64-pc-windows-msvc
             use-zigbuild: false # zigbuild doesn't support Windows
             strip: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,21 +20,21 @@ jobs:
             use-zigbuild: false # no reason to use zigbuild when building for host
             strip: true
             artifact: linux-x64
-          # - os: ubuntu-latest
-          #   target: aarch64-unknown-linux-gnu
-          #   use-zigbuild: true
-          #   strip: false
-          #   artifact: linux-arm64
-          # - os: macos-latest
-          #   target: x86_64-apple-darwin
-          #   use-zigbuild: true
-          #   strip: true
-          #   artifact: macos-x64
-          # - os: macos-latest
-          #   target: aarch64-apple-darwin
-          #   use-zigbuild: true
-          #   strip: false
-          #   artifact: macos-arm64
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            use-zigbuild: true
+            strip: false
+            artifact: linux-arm64
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            use-zigbuild: true
+            strip: true
+            artifact: macos-x64
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            use-zigbuild: true
+            strip: false
+            artifact: macos-arm64
           # - os: windows-latest
           - os: ubuntu-latest
             target: x86_64-pc-windows-gnu
@@ -42,12 +42,12 @@ jobs:
             use-zigbuild: false # zigbuild doesn't support Windows
             strip: false
             artifact: windows-x64.exe
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            extension: exe
-            use-zigbuild: false
-            strip: false
-            artifact: windows2-x64.exe
+          # - os: windows-latest
+          #   target: x86_64-pc-windows-msvc
+          #   extension: exe
+          #   use-zigbuild: false
+          #   strip: false
+          #   artifact: windows2-x64.exe
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,29 +92,6 @@ jobs:
     needs: build
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: AsimovPlatform/release-action@master
         with:
-          path: artifacts
-          merge-multiple: true
-      - name: Compute checksums for artifacts
-        run: |
-          for file in artifacts/*; do
-            shasum --algorithm 256 "$file" > "$file.sha256"
-          done
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          path: repo
-      - name: Parse changelog
-        id: query-release-info
-        uses: release-flow/keep-a-changelog-action@v3
-        with:
-          command: query
-          version: latest
-          changelog: repo/CHANGES.md
-      - name: Create release
-        uses: softprops/action-gh-release@v2
-        with:
-          body: ${{ steps.query-release-info.outputs.release-notes }}
-          tag_name: ${{ github.ref_name }}
-          files: artifacts/*
+          changelog_path: CHANGES.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
           mv target/${{ matrix.target }}/release/protoflow${{ matrix.os == 'windows-latest' && '.exe' || '' }} .output/${{ matrix.artifact }}
       - name: Compress artifact
         if: ${{ matrix.os != 'windows-latest' }}
-        working-directory: output
+        working-directory: .output
         run: gzip -f *
       - name: Archive artifact
         if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Rust and target
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,21 +20,21 @@ jobs:
             use-zigbuild: false # no reason to use zigbuild when building for host
             strip: true
             artifact: protoflow-linux-x64
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-            use-zigbuild: true
-            strip: false
-            artifact: protoflow-linux-arm64
-          - os: macos-latest
-            target: x86_64-apple-darwin
-            use-zigbuild: true
-            strip: true
-            artifact: protoflow-darwin-x64
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            use-zigbuild: true
-            strip: false
-            artifact: protoflow-darwin-arm64
+          # - os: ubuntu-latest
+          #   target: aarch64-unknown-linux-gnu
+          #   use-zigbuild: true
+          #   strip: false
+          #   artifact: protoflow-linux-arm64
+          # - os: macos-latest
+          #   target: x86_64-apple-darwin
+          #   use-zigbuild: true
+          #   strip: true
+          #   artifact: protoflow-darwin-x64
+          # - os: macos-latest
+          #   target: aarch64-apple-darwin
+          #   use-zigbuild: true
+          #   strip: false
+          #   artifact: protoflow-darwin-arm64
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             use-zigbuild: false # zigbuild doesn't support Windows
@@ -43,48 +43,14 @@ jobs:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Install Rust and target
-        uses: dtolnay/rust-toolchain@stable
+      - name: Build
+        uses: AsimovPlatform/build-rust-action@master
         with:
           target: ${{ matrix.target }}
-      - name: Install zig
-        if: ${{ matrix.use-zigbuild }}
-        uses: mlugg/setup-zig@v1
-      - name: Install cargo-zigbuild
-        if: ${{ matrix.use-zigbuild }}
-        run: cargo install --locked cargo-zigbuild
-      - name: Build using cargo-zigbuild
-        if: ${{ matrix.use-zigbuild }}
-        run: cargo zigbuild --release --target ${{ matrix.target }}
-      - name: Build
-        if: ${{ !matrix.use-zigbuild }}
-        run: cargo build --release --target ${{ matrix.target }}
-      - name: Rename artifact
-        run: |
-          mkdir output
-          mv target/${{ matrix.target }}/release/protoflow${{ matrix.os == 'windows-latest' && '.exe' || '' }} output/${{ matrix.artifact }}
-      - name: Strip artifact (*nix)
-        if: ${{ matrix.strip }}
-        working-directory: output
-        run: strip ${{ matrix.artifact }}
-      - name: Compress artifact (*nix)
-        if: ${{ matrix.os != 'windows-latest' }}
-        working-directory: output
-        run: gzip -f ${{ matrix.artifact }}
-      - name: Archive artifact (Windows)
-        if: ${{ matrix.os == 'windows-latest' }}
-        working-directory: output
-        run: |
-          7z a -tzip ${{ matrix.artifact }}.zip *
-          rm ${{ matrix.artifact }}
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.target }}
-          path: output/*
-          if-no-files-found: error
+          artifact-name: ${{ matrix.artifact }}
+          strip: ${{ matrix.strip }}
+          use-zigbuild: ${{ matrix.use-zigbuild }}
+
   release:
     name: Release
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,18 +55,6 @@ jobs:
             extension: exe
             use-zigbuild: false
             strip: false
-          - os: ubuntu-latest
-            artifact: windows-x64-msvc
-            target: x86_64-pc-windows-msvc
-            extension: exe
-            use-zigbuild: false
-            strip: false
-          - os: ubuntu-latest
-            artifact: windows-arm64
-            target: aarch64-pc-windows-msvc
-            extension: exe
-            use-zigbuild: false
-            strip: false
           # Windows native
           - os: windows-latest
             artifact: windows-native-x64-gnu
@@ -98,6 +86,7 @@ jobs:
           artifact-name: ${{ matrix.artifact }}
           strip: ${{ matrix.strip || 'false' }}
           use-zigbuild: ${{ matrix.use-zigbuild || 'false' }}
+          rust-toolchain: 1.81.0
 
   release:
     name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,11 @@
 name: Release
 
+# TODO:
+# - Strip binaries.
+# - Support signing macos binaries.
+# - Specify hashes in release.
+# - Produce targball on unix and zip on windows.
+
 # Trigger on any tag creation.
 on:
   push:
@@ -56,5 +62,20 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }}
       - uses: actions/upload-artifact@v4
         with:
-          name: release-${{ matrix.target }}
+          name: protoflow-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/${{ matrix.artifact }}
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: github.event.ref_type == 'tag'
+    needs: build
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: './artifacts'
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: artifacts/**/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@ name: Release
 
 # TODO:
 # - Support signing macos binaries.
-# - Pull changes from changes.md
 
 # Trigger on any tag creation.
 on:
@@ -95,13 +94,17 @@ jobs:
           for file in artifacts/*; do
             shasum --algorithm 256 "$file" > "$file.sha256"
           done
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          path: repo
       - name: Parse changelog
         id: query-release-info
         uses: release-flow/keep-a-changelog-action@v2
         with:
           command: query
           version: latest
-          changelog: CHANGES.md
+          changelog: repo/CHANGES.md
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,11 @@ jobs:
             use-zigbuild: false # zigbuild doesn't support Windows
             strip: false
             artifact: windows-x64.exe
+          - os: windows-latest
+            target: x86_64-pc-windows-gnu
+            use-zigbuild: false
+            strip: false
+            artifact: windows2-x64.exe
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,22 +18,27 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             use-zigbuild: false # no reason to use zigbuild when building for host
+            strip: true
             artifact: protoflow-linux-x64
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             use-zigbuild: true
+            strip: false
             artifact: protoflow-linux-arm64
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            use-zigbuild: true
-            artifact: protoflow-darwin-arm64
           - os: macos-latest
             target: x86_64-apple-darwin
             use-zigbuild: true
+            strip: true
             artifact: protoflow-darwin-x64
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            use-zigbuild: true
+            strip: false
+            artifact: protoflow-darwin-arm64
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             use-zigbuild: false # zigbuild doesn't support Windows
+            strip: false
             artifact: protoflow-windows-x64.exe
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
@@ -61,7 +66,7 @@ jobs:
           mkdir output
           mv target/${{ matrix.target }}/release/protoflow${{ matrix.os == 'windows-latest' && '.exe' || '' }} output/${{ matrix.artifact }}
       - name: Strip artifact (*nix)
-        if: ${{ matrix.os != 'windows-latest' }}
+        if: ${{ matrix.strip }}
         working-directory: output
         run: strip ${{ matrix.artifact }}
       - name: Compress artifact (*nix)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,7 @@ name: Release
 # TODO:
 # - Strip binaries.
 # - Support signing macos binaries.
-# - Specify hashes in release.
-# - Produce .gz on unix and .zip on windows.
+# - Pull changes from changes.md
 
 # Trigger on any tag creation.
 on:
@@ -63,13 +62,24 @@ jobs:
         run: |
           mkdir output
           mv target/${{ matrix.target }}/release/protoflow${{ matrix.os == 'windows-latest' && '.exe' || '' }} output/${{ matrix.artifact }}
-      - name: Compress artifact
+      - name: Compress artifact (*nix)
         if: ${{ matrix.os != 'windows-latest' }}
         working-directory: output
         run: gzip -f ${{ matrix.artifact }}
-      - name: Archive artifact
+      - name: Archive artifact (Windows)
         if: ${{ matrix.os == 'windows-latest' }}
-        run: 7z a -tzip output/${{ matrix.artifact }}.zip output/*
+        working-directory: output
+        run: 7z a -tzip ${{ matrix.artifact }}.zip *
+      - name: Compute hash (*nix)
+        working-directory: output
+        run: 
+          shasum --algorithm 256 "${{ matrix.artifact }}" > "${{ matrix.artifact }}.sha256"
+      - name: Compute hash (Windows)
+        working-directory: output
+        run: |
+          choco install --ignore-checksums dos2unix psutils
+          shasum --algorithm 256 "${{ matrix.artifact }}" > "${{ matrix.artifact }}.sha256"
+          dos2unix "${{ matrix.artifact }}.sha256"
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
           version: latest
           changelog: repo/CHANGES.md
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           body: ${{ steps.query-release-info.outputs.release-notes }}
           tag_name: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: artifacts
-      - name: List artifacts
+          merge-multiple: true
+      - name: '[DEBUG] List artifacts'
         run: ls -R artifacts
       - name: Create release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,11 +38,13 @@ jobs:
           # - os: windows-latest
           - os: ubuntu-latest
             target: x86_64-pc-windows-gnu
+            package-extension: exe
             use-zigbuild: false # zigbuild doesn't support Windows
             strip: false
             artifact: windows-x64.exe
           - os: windows-latest
             target: x86_64-pc-windows-msvc
+            package-extension: exe
             use-zigbuild: false
             strip: false
             artifact: windows2-x64.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,15 +15,23 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            use-zigbuild: false
+            use-zigbuild: false # no reason to use zigbuild when building for host
             artifact: protoflow
-          # - os: macos-latest
-          #   target: x86_64-apple-darwin
-          #   use-zigbuild: true
-          #   artifact: protoflow
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            use-zigbuild: true
+            artifact: protoflow
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            use-zigbuild: true
+            artifact: protoflow
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            use-zigbuild: true
+            artifact: protoflow
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            use-zigbuild: false
+            use-zigbuild: false # zigbuild doesn't support Windows
             artifact: protoflow.exe
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,28 +19,28 @@ jobs:
             target: x86_64-unknown-linux-gnu
             use-zigbuild: false # no reason to use zigbuild when building for host
             strip: true
-            artifact: protoflow-linux-x64
+            artifact: linux-x64
           # - os: ubuntu-latest
           #   target: aarch64-unknown-linux-gnu
           #   use-zigbuild: true
           #   strip: false
-          #   artifact: protoflow-linux-arm64
+          #   artifact: linux-arm64
           # - os: macos-latest
           #   target: x86_64-apple-darwin
           #   use-zigbuild: true
           #   strip: true
-          #   artifact: protoflow-macos-x64
+          #   artifact: macos-x64
           # - os: macos-latest
           #   target: aarch64-apple-darwin
           #   use-zigbuild: true
           #   strip: false
-          #   artifact: protoflow-macos-arm64
+          #   artifact: macos-arm64
           # - os: windows-latest
           - os: ubuntu-latest
             target: x86_64-pc-windows-gnu
             use-zigbuild: false # zigbuild doesn't support Windows
             strip: false
-            artifact: protoflow-windows-x64.exe
+            artifact: windows-x64.exe
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
             strip: false
             artifact: windows-x64.exe
           - os: windows-latest
-            target: x86_64-pc-windows-gnu
+            target: x86_64-pc-windows-msvc
             use-zigbuild: false
             strip: false
             artifact: windows2-x64.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,22 +19,22 @@ jobs:
             target: x86_64-unknown-linux-gnu
             use-zigbuild: false # no reason to use zigbuild when building for host
             artifact: protoflow-linux-x64
-          # - os: ubuntu-latest
-          #   target: aarch64-unknown-linux-gnu
-          #   use-zigbuild: true
-          #   artifact: protoflow-linux-arm64
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            use-zigbuild: true
+            artifact: protoflow-linux-arm64
           - os: macos-latest
             target: aarch64-apple-darwin
             use-zigbuild: true
             artifact: protoflow-darwin-arm64
-          # - os: macos-latest
-          #   target: x86_64-apple-darwin
-          #   use-zigbuild: true
-          #   artifact: protoflow-darwin-x64
-          # - os: windows-latest
-          #   target: x86_64-pc-windows-msvc
-          #   use-zigbuild: false # zigbuild doesn't support Windows
-          #   artifact: protoflow-windows-x64.exe
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            use-zigbuild: true
+            artifact: protoflow-darwin-x64
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            use-zigbuild: false # zigbuild doesn't support Windows
+            artifact: protoflow-windows-x64.exe
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,13 +41,13 @@ jobs:
             extension: exe
             use-zigbuild: false # zigbuild doesn't support Windows
             strip: false
-            artifact: windows-x64.exe
-          # - os: windows-latest
-          #   target: x86_64-pc-windows-msvc
-          #   extension: exe
-          #   use-zigbuild: false
-          #   strip: false
-          #   artifact: windows2-x64.exe
+            artifact: windows-x64
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            extension: exe
+            use-zigbuild: false
+            strip: false
+            artifact: windows-native-x64
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,39 +15,65 @@ jobs:
       fail-fast: true
       matrix:
         include:
+          # Linux native
           - os: ubuntu-latest
+            artifact: linux-x64
             target: x86_64-unknown-linux-gnu
             use-zigbuild: false # no reason to use zigbuild when building for host
             strip: true
-            artifact: linux-x64
           - os: ubuntu-latest
+            artifact: linux-arm64
             target: aarch64-unknown-linux-gnu
             use-zigbuild: true
             strip: false
-            artifact: linux-arm64
-          - os: macos-latest
+          # Linux to macOS
+          - os: ubuntu-latest
+            artifact: macos-x64
             target: x86_64-apple-darwin
             use-zigbuild: true
             strip: true
-            artifact: macos-x64
-          - os: macos-latest
+          - os: ubuntu-latest
+            artifact: macos-arm64
             target: aarch64-apple-darwin
             use-zigbuild: true
             strip: false
-            artifact: macos-arm64
-          # - os: windows-latest
+          # macOS native
+          - os: macos-latest
+            artifact: macos-native-x64
+            target: x86_64-apple-darwin
+            use-zigbuild: false
+            strip: true
+          - os: macos-latest
+            artifact: macos-native-arm64
+            target: aarch64-apple-darwin
+            use-zigbuild: false
+            strip: false
+          # Linux to Windows
           - os: ubuntu-latest
+            artifact: windows-x64
             target: x86_64-pc-windows-gnu
             extension: exe
             use-zigbuild: false # zigbuild doesn't support Windows
             strip: false
-            artifact: windows-x64
+          - os: ubuntu-latest
+            artifact: windows-arm64
+            target: aarch64-pc-windows-msvc
+            extension: exe
+            use-zigbuild: false
+            strip: false
+          # Windows native
           - os: windows-latest
+            artifact: windows-native-x64
             target: x86_64-pc-windows-msvc
             extension: exe
             use-zigbuild: false
             strip: false
-            artifact: windows-native-x64
+          - os: windows-latest
+            artifact: windows-native-arm64
+            target: aarch64-pc-windows-msvc
+            extension: exe
+            use-zigbuild: false
+            strip: false
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,8 +95,16 @@ jobs:
           for file in artifacts/*; do
             shasum --algorithm 256 "$file" > "$file.sha256"
           done
+      - name: Parse changelog
+        id: query-release-info
+        uses: release-flow/keep-a-changelog-action@v2
+        with:
+          command: query
+          version: latest
+          changelog: CHANGES.md
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
+          body: ${{ steps.query-release-info.outputs.release-notes }}
           tag_name: ${{ github.ref_name }}
           files: artifacts/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,10 +50,16 @@ jobs:
             strip: false
           # Linux to Windows
           - os: ubuntu-latest
-            artifact: windows-x64
+            artifact: windows-x64-gnu
             target: x86_64-pc-windows-gnu
             extension: exe
-            use-zigbuild: false # zigbuild doesn't support Windows
+            use-zigbuild: false
+            strip: false
+          - os: ubuntu-latest
+            artifact: windows-x64-msvc
+            target: x86_64-pc-windows-msvc
+            extension: exe
+            use-zigbuild: false
             strip: false
           - os: ubuntu-latest
             artifact: windows-arm64
@@ -63,7 +69,13 @@ jobs:
             strip: false
           # Windows native
           - os: windows-latest
-            artifact: windows-native-x64
+            artifact: windows-native-x64-gnu
+            target: x86_64-pc-windows-gnu
+            extension: exe
+            use-zigbuild: false
+            strip: false
+          - os: windows-latest
+            artifact: windows-native-x64-msvc
             target: x86_64-pc-windows-msvc
             extension: exe
             use-zigbuild: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build
         if: ${{ !matrix.use-zigbuild }}
         run: cargo build --release --target ${{ matrix.target }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: release-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/${{ matrix.artifact }}

--- a/lib/protoflow-blocks/Cargo.toml
+++ b/lib/protoflow-blocks/Cargo.toml
@@ -16,7 +16,7 @@ publish.workspace = true
 
 [features]
 default = ["all", "std"]
-all = ["rand", "serde", "sysml", "tracing"]
+all = ["hash", "rand", "serde", "sysml", "tracing"]
 hash = ["dep:blake3"]
 rand = ["protoflow-core/rand"]
 std = [

--- a/lib/protoflow-blocks/Cargo.toml
+++ b/lib/protoflow-blocks/Cargo.toml
@@ -16,7 +16,7 @@ publish.workspace = true
 
 [features]
 default = ["all", "std"]
-all = ["hash", "rand", "serde", "sysml", "tracing"]
+all = ["rand", "serde", "sysml", "tracing"]
 hash = ["dep:blake3"]
 rand = ["protoflow-core/rand"]
 std = [


### PR DESCRIPTION
This PR implements a simple CD workflow that would use our build-rust-action and release-action to automatically generate a release each time a tag is pushed.

Here is the end result:
![image](https://github.com/user-attachments/assets/281fb48a-f968-4f79-b0ea-7e8a2284d725)

Currently always runs on ubuntu-latest and builds for the next targets:
- x86_64-unknown-linux-gnu
- aarch64-unknown-linux-gnu
- x86_64-apple-darwin
- aarch64-apple-darwin
- x86_64-pc-windows-gnu

Please note: In 1.82 version of Rust there is currently a regression, which causes zigbuild targeting macos to fail. That's why it's currently hardcoded to Rust version 1.81.